### PR TITLE
Effects only accept strict input/output/pollution now

### DIFF
--- a/src/main/java/sk/uniba/fmph/dcs/terra_futura/effect/AssistanceEffect.java
+++ b/src/main/java/sk/uniba/fmph/dcs/terra_futura/effect/AssistanceEffect.java
@@ -21,6 +21,7 @@ public class AssistanceEffect implements Effect {
         JSONObject json = new JSONObject();
         json.put("input", new int[] {});
         json.put("output", new String[] {"Assistance"});
+        json.put("pollution", 0);
         return json.toString();
     }
 }

--- a/src/main/java/sk/uniba/fmph/dcs/terra_futura/effect/Effect.java
+++ b/src/main/java/sk/uniba/fmph/dcs/terra_futura/effect/Effect.java
@@ -17,8 +17,8 @@ public interface Effect {
     boolean hasAssistance();
 
     /**
-     * Gives the state of an effect, which is always either a json  object with a (possibly empty) input list
-     * and a (non-empty) output list, or a json list of such objects.
+     * Gives the state of an effect, which is always either a json  object with a (possibly empty) input list,
+     * a (non-empty) output list and the pollution number, or a json list of such objects.
      * @return string representing the state's json object
      */
     String state();

--- a/src/main/java/sk/uniba/fmph/dcs/terra_futura/effect/ExchangeEffect.java
+++ b/src/main/java/sk/uniba/fmph/dcs/terra_futura/effect/ExchangeEffect.java
@@ -5,31 +5,38 @@ import sk.uniba.fmph.dcs.terra_futura.Resource;
 
 import java.util.*;
 
+/**
+ * Represents a simple exchange effect, i.e. an effect that takes a given list of input resources and puts a list of
+ * output resources on the card.
+ */
 public class ExchangeEffect implements Effect {
-    /**
-     * Represents a simple exchange effect, i.e. an effect that takes a given list of input resources and puts a list of
-     * output resources on the card.
-     */
     private final List<Resource> input;
     private final List<Resource> output;
+    private final int pollution;
 
     public ExchangeEffect(List<Resource> input, List<Resource> output) {
+        this(input, output, 0);
+    }
+
+    public ExchangeEffect(List<Resource> input, List<Resource> output, int pollution) {
         this.input = new ArrayList<>(input);
         this.output = new ArrayList<>(output);
+        this.pollution = pollution;
     }
 
     @Override
     public boolean check(List<Resource> input, List<Resource> output, int pollution) {
+        // check added pollution
+        if (pollution != this.pollution) {
+            return false;
+        }
         for (Resource resource : Resource.values()) {
             // check if this effect's inputs are not present in the given input
-            if (Collections.frequency(input, resource) < Collections.frequency(this.input, resource)){
+            if (Collections.frequency(input, resource) != Collections.frequency(this.input, resource)){
                 return false;
             }
             // check if output is incorrect after using this effect given inputs
-            if (Collections.frequency(output, resource)
-                    != Collections.frequency(input, resource)
-                     - Collections.frequency(this.input, resource)
-                     + Collections.frequency(this.output, resource)
+            if (Collections.frequency(output, resource) != Collections.frequency(this.output, resource)
             ) {
                 return false;
             }
@@ -48,6 +55,7 @@ public class ExchangeEffect implements Effect {
         JSONObject json = new JSONObject();
         json.put("input", input);
         json.put("output", output);
+        json.put("pollution", pollution);
         return json.toString();
     }
 }

--- a/src/main/java/sk/uniba/fmph/dcs/terra_futura/effect/GainEffect.java
+++ b/src/main/java/sk/uniba/fmph/dcs/terra_futura/effect/GainEffect.java
@@ -18,7 +18,10 @@ public class GainEffect implements Effect {
 
     @Override
     public boolean check(List<Resource> input, List<Resource> output, int pollution) {
-        return (Collections.frequency(output, this.output) == Collections.frequency(input, this.output) + 1);
+        return pollution == 0 &&
+                input.isEmpty() &&
+                output.size() == 1 &&
+                output.getFirst() == this.output;
     }
 
     @Override
@@ -31,6 +34,7 @@ public class GainEffect implements Effect {
         JSONObject json = new JSONObject();
         json.put("input", new int[] {});
         json.put("output", new Resource[] {output});
+        json.put("pollution", 0);
         return json.toString();
     }
 }


### PR DESCRIPTION
Looking at some other code and game logic, the appropriate approach to effects turns out to be accepting only lists of ins/outs/pollution such that they can are strictly equal to what can be taken-produced using the effect. Otherwise, the player could move arbitrary resources on active cards freely to the activated card by selecting one more input and one more output